### PR TITLE
patch typo in welcome paragraph

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,6 +1,6 @@
 # Welcome
 
-Resque is a Redis-backed ruby library for creating background jobs, placing those jobs on multiple queues, and processing them later. Unlike [Sidekiq](https://sidekiq.org) (an well-designed & well-maintained alternative!) it forks a new process for each job, which makes it resilient to memory leaks and eliminates thread-safety concerns. It's been battle-tested with high production loads and has a robust ecosystem of plugins to fill various needs.
+Resque is a Redis-backed ruby library for creating background jobs, placing those jobs on multiple queues, and processing them later. Unlike [Sidekiq](https://sidekiq.org) (a well-designed & well-maintained alternative!) it forks a new process for each job, which makes it resilient to memory leaks and eliminates thread-safety concerns. It's been battle-tested with high production loads and has a robust ecosystem of plugins to fill various needs.
 
 [View on Github](https://github.com/resque/resque)
 


### PR DESCRIPTION
The line in the welcome paragraph referencing Sidekiq. The term _an_ is used where (grammatically) it should be _a_.